### PR TITLE
fix(package): update main and types fields to use project_name template

### DIFF
--- a/src/commands/templates/gen-typescript/package.json.tpl
+++ b/src/commands/templates/gen-typescript/package.json.tpl
@@ -2,8 +2,8 @@
   "name": "{{project_name}}",
   "version": "{{protocol_version}}",
   "description": "A simple Node.js library for the TX3 protocol",
-  "main": "dist/example.js",
-  "types": "dist/example.d.ts",
+  "main": "dist/{{project_name}}.js",
+  "types": "dist/{{project_name}}.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "tsx ./test"


### PR DESCRIPTION
Update wrong main/types fields when protocol isn't called example.