### PR TITLE
feat: add support for bindgen options argument on trix.toml

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -131,6 +131,7 @@ pub fn run(args: Args, config: Option<&Config>) -> miette::Result<()> {
             .map(|binding| BindingsConfig {
                 output_dir: PathBuf::from(format!("./gen/{}", binding.to_string().to_lowercase())),
                 plugin: binding.to_string().to_lowercase(),
+                options: None,
             })
             .collect(),
         profiles: ProfilesConfig::default().into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,6 +200,10 @@ impl From<KnownChain> for U5cConfig {
 pub struct BindingsConfig {
     pub plugin: String,
     pub output_dir: PathBuf,
+    /// Additional options for the binding generation in command-line argument format
+    /// Example: "--template=standalone --feature=async,types --target=node"
+    /// This will be parsed and used by kickstart library for template processing
+    pub options: Option<String>,
 }
 
 impl Config {


### PR DESCRIPTION
This PR adds support for optional options on trix.toml file that will be used by bindgen.

Example
```toml
[[bindings]]
plugin = "typescript"
output_dir = "./gen/typescript"

[[bindings]]
plugin = "typescript"
output_dir = "./gen/typescript-standalone"
options = "--template=standalone"
```

The first binding, will generate a `gen/typescript` folder with `package.json`, `tsconfig.json` and `protocol.ts` files.
Meanwhile, the second binding, will generate a `gen/typescript-standalone` folder with `protocol.ts` file.

---
With this update, is possible (but not required) to create a `config.toml` on `bindgen` folder with template definitions. For example, for typescript, this is how the config.toml looks like

```toml
all = [
  "package.json.hbs",
  "protocol.ts.hbs",
  "tsconfig.json.hbs"
]

standalone = [
  "protocol.ts.hbs"
]
```
When we use `--template=standalone` we based on 
```toml
standalone = [
  "protocol.ts.hbs"
]
```
to generate the output code