### PR TITLE
feat: support dynamic options, static files and multiple templates

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::config::{BindingsConfig, Config, ProfilesConfig, ProtocolConfig, RegistryConfig};
+use crate::config::{BindingsConfig, BindingsTemplateConfig, Config, ProfilesConfig, ProtocolConfig, RegistryConfig};
 use clap::Args as ClapArgs;
 use inquire::{Confirm, MultiSelect, Text};
 use miette::IntoDiagnostic;
@@ -130,7 +130,8 @@ pub fn run(args: Args, config: Option<&Config>) -> miette::Result<()> {
             .iter()
             .map(|binding| BindingsConfig {
                 output_dir: PathBuf::from(format!("./gen/{}", binding.to_string().to_lowercase())),
-                plugin: binding.to_string().to_lowercase(),
+                plugin: None, // Deprecated
+                template: BindingsTemplateConfig::from_plugin(binding.to_lowercase().as_str()),
                 options: None,
             })
             .collect(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -197,8 +197,58 @@ impl From<KnownChain> for U5cConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BindingsTemplateConfig {
+    pub repo: String,
+    pub path: String,
+    pub r#ref: Option<String>, // default: main
+}
+
+impl Default for BindingsTemplateConfig {
+    fn default() -> Self {
+        Self {
+            repo: String::new(),
+            path: "bindgen".to_string(),
+            r#ref: None,
+        }
+    }
+}
+
+impl BindingsTemplateConfig {
+    // Unify the creation of BindingsTemplateConfig from plugin name
+    pub fn from_plugin(plugin: &str) -> Self {
+        match plugin {
+            "typescript" => BindingsTemplateConfig {
+                repo: "tx3-lang/web-sdk".to_string(),
+                path: "bindgen/client-lib".to_string(),
+                r#ref: None,
+            },
+            "rust" => BindingsTemplateConfig {
+                repo: "tx3-lang/rust-sdk".to_string(),
+                path: "bindgen".to_string(),
+                r#ref: None,
+            },
+            "python" => BindingsTemplateConfig {
+                repo: "tx3-lang/python-sdk".to_string(),
+                path: "bindgen".to_string(),
+                r#ref: None,
+            },
+            "go" => BindingsTemplateConfig {
+                repo: "tx3-lang/go-sdk".to_string(),
+                path: "bindgen".to_string(),
+                r#ref: None,
+            },
+            _ => BindingsTemplateConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BindingsConfig {
-    pub plugin: String,
+    // Deprecated field, use template instead
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plugin: Option<String>,
+    #[serde(default)]
+    pub template: BindingsTemplateConfig,
     pub output_dir: PathBuf,
     pub options: Option<HashMap<String, serde_json::Value>>,
 }
@@ -206,7 +256,16 @@ pub struct BindingsConfig {
 impl Config {
     pub fn load(path: &PathBuf) -> miette::Result<Config> {
         let contents = std::fs::read_to_string(path).into_diagnostic()?;
-        let config = toml::from_str(&contents).into_diagnostic()?;
+        let mut config: Config = toml::from_str(&contents).into_diagnostic()?;
+
+        // Post-process bindings to handle backward compatibility
+        // Eventually, this should be removed once deprecated plugin option is removed
+        for binding in &mut config.bindings {
+            if binding.template.repo.is_empty() && binding.plugin.is_some() {
+                binding.template = BindingsTemplateConfig::from_plugin(binding.plugin.as_ref().unwrap());
+            }
+        }
+
         Ok(config)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -197,15 +197,10 @@ impl From<KnownChain> for U5cConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct BindingOptions {
-    pub standalone: Option<bool>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BindingsConfig {
     pub plugin: String,
     pub output_dir: PathBuf,
-    pub options: Option<BindingOptions>,
+    pub options: Option<HashMap<String, serde_json::Value>>,
 }
 
 impl Config {


### PR DESCRIPTION
This pr's adds new logic to bindgen supporting static files and dynamic options. Those options will get pass to handlebars as data which will be used internally.

Added new `template` property on bindings and deprecate `plugin` property.
This new `template` property allow to define the repository to take the template, the path from root to it and a `ref` which could be a branch or commit from where to take the template. If `ref` is missing, main will be the default one

Web-sdk template is updated on https://github.com/tx3-lang/web-sdk/pull/18 and can be used as 
```toml
[[bindings]]
template = { repo = "tx3-lang/web-sdk", path = "bindgen/client-lib", ref = "main" }
output_dir = "./gen/typescript/standalone"
options = { standalone = true }

[[bindings]]
template = { repo = "tx3-lang/web-sdk", path = "bindgen/client-lib" }
output_dir = "./gen/typescript/protocol-only"
options = { standalone = false }
```
and the output for this will  be 
<img width="130" height="158" alt="image" src="https://github.com/user-attachments/assets/bb6119e2-01ab-4e75-ae6f-54ca7aa8a239" />

