### PR TITLE
feat: imports command added

### DIFF
--- a/src/commands/inspect/imports.rs
+++ b/src/commands/inspect/imports.rs
@@ -1,0 +1,41 @@
+use clap::Args as ClapArgs;
+use miette::{Context as _, IntoDiagnostic as _};
+
+use crate::config::RootConfig;
+use crate::dirs;
+
+#[derive(ClapArgs)]
+pub struct Args {
+    /// Path to plutus.json (relative to project root or absolute)
+    #[arg(long)]
+    path: String,
+
+    /// Optional alias (same as in `import "…" as alias;`)
+    #[arg(long)]
+    alias: Option<String>,
+}
+
+pub fn run(args: Args, _config: &RootConfig) -> miette::Result<()> {
+    let root = dirs::protocol_root()?;
+    let loader = tx3_lang::importing::FsLoader::new(root);
+
+    let type_defs = tx3_lang::importing::types_from_plutus(
+        &args.path,
+        args.alias.as_deref(),
+        &loader,
+    )
+    .into_diagnostic()
+    .with_context(|| format!("loading {}", args.path))?;
+
+    let alias_label = args
+        .alias
+        .as_deref()
+        .map(|a| format!(" (alias: {})", a))
+        .unwrap_or_default();
+    println!("Types from {}{}:", args.path, alias_label);
+    for type_def in &type_defs {
+        println!("{}", type_def.to_tx3_source());
+    }
+
+    Ok(())
+}

--- a/src/commands/inspect/mod.rs
+++ b/src/commands/inspect/mod.rs
@@ -2,10 +2,14 @@ use clap::{Args as ClapArgs, Subcommand};
 
 use crate::config::RootConfig;
 
+mod imports;
 mod tir;
 
 #[derive(Subcommand)]
 pub enum Command {
+    /// Inspect types available from a plutus.json (CIP57) file
+    Imports(imports::Args),
+
     /// Inspect the intermediate representation of a transaction
     Tir(tir::Args),
 }
@@ -18,6 +22,7 @@ pub struct Args {
 
 pub fn run(args: Args, config: &RootConfig) -> miette::Result<()> {
     match args.command {
+        Command::Imports(args) => imports::run(args, config),
         Command::Tir(args) => tir::run(args, config),
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to the `inspect` command, allowing users to inspect types available from a `plutus.json` (CIP57) file. The main changes add a new subcommand, implement its argument parsing, and provide the logic to load and display type definitions from the specified file. It relies on [this PR](https://github.com/tx3-lang/tx3/pull/289) being merged

New `inspect imports` subcommand:

**Feature: Imports inspection**
* Added a new `Imports` subcommand to the `inspect` command, enabling inspection of types from a `plutus.json` file.
* Implemented the argument parsing and command logic in `src/commands/inspect/imports.rs`, including support for specifying the file path and an optional alias, loading type definitions, and printing them in source format.
* Integrated the new subcommand with the main `inspect` command runner, dispatching to the `imports::run` function when the `Imports` variant is selected.