### PR TITLE
feat: look up tools on PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.20.1] - UNRELEASED
+
+- Look on PATH for tools (e.g. tx3c)
+
 ## [0.20.0] - 2026-02-14
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4413,6 +4419,7 @@ dependencies = [
  "tx3-lang",
  "tx3-tir",
  "utxorpc",
+ "which",
  "zip",
 ]
 
@@ -4746,6 +4753,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5066,6 +5085,12 @@ checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trix"
 description = "The Tx3 package manager"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 repository = "https://github.com/tx3-lang/trix"
 homepage = "https://github.com/tx3-lang/trix"
@@ -57,6 +57,7 @@ tracing = "0.1"
 tokio-util = "0.7"
 tracing-subscriber = "0.3.22"
 dotenv-parser = "0.1.3"
+which = "7"
 termimad = "0.31"
 
 [dev-dependencies]

--- a/src/home.rs
+++ b/src/home.rs
@@ -64,10 +64,15 @@ pub fn custom_tool_path(name: &str) -> miette::Result<Option<PathBuf>> {
 }
 
 pub fn tool_path(name: &str) -> miette::Result<PathBuf> {
-    match custom_tool_path(name)? {
-        Some(path) => Ok(path),
-        None => default_tool_path(name),
+    if let Some(path) = custom_tool_path(name)? {
+        return Ok(path);
     }
+
+    if let Ok(path) = which::which(name) {
+        return Ok(path);
+    }
+
+    default_tool_path(name)
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Add a $PATH lookup as a third option in tool_path(), so the resolution becomes:

1. `TX3_{NAME}_PATH` env var (unchanged)
2. Search $PATH for the tool (new — higher priority than hardcoded dir)
3. `~/.tx3/default/bin/{name}` (unchanged, now last resort)

This way, if a user has `tx3c` on their `PATH` (e.g. via nix shell), it takes precedence over whatever is in `~/.tx3/default/bin/`.