### PR TITLE
chore: update tx3up install URL after up→tx3up rename

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install tx3up
-      run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh
+      run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
       shell: bash
 
     - name: Install tools


### PR DESCRIPTION
The `tx3-lang/up` repository was renamed to `tx3-lang/tx3up`. This updates the `tx3up` install snippet in the setup composite action.

GitHub redirects keep the old URL working, so this is a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)