### PR TITLE
fix: remove unstable feature gate from publish command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,6 @@ predicates = "3.1"
 insta = "1.42"
 libc = "0.2"
 
-[features]
-unstable = []
-
 [lib]
 name = "trix"
 path = "src/lib.rs"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,8 +54,7 @@ pub enum Commands {
     /// Inspect and manage profiles
     Profile(commands::profile::Args),
 
-    /// Publish a Tx3 package into the registry (UNSTABLE - This feature is experimental and may change)
-    #[command(hide = true)]
+    /// Publish a Tx3 package into the registry
     Publish(commands::publish::Args),
 
     /// Add a published protocol as an interface

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -8,10 +8,8 @@ use clap::Args as ClapArgs;
 use miette::IntoDiagnostic as _;
 
 #[derive(ClapArgs)]
-/// Arguments for the publish command (UNSTABLE - experimental feature)
 pub struct Args {}
 
-#[allow(dead_code)]
 fn get_image_url(config: &RootConfig) -> String {
     let registry_url = config.registry_url();
     format!(
@@ -21,21 +19,6 @@ fn get_image_url(config: &RootConfig) -> String {
         config.protocol.name.clone(),
         config.protocol.version.clone()
     )
-}
-
-#[allow(unused_variables)]
-pub fn run(_args: Args, config: &RootConfig) -> miette::Result<()> {
-    #[cfg(feature = "unstable")]
-    {
-        _run(_args, config)
-    }
-    #[cfg(not(feature = "unstable"))]
-    {
-        let _ = config;
-        Err(miette::miette!(
-            "The publish command is currently unstable and requires the `unstable` feature to be enabled."
-        ))
-    }
 }
 
 /// Best-effort capture of the publishing working tree's HEAD commit. Used
@@ -54,8 +37,7 @@ fn capture_commit_sha() -> Option<String> {
     if s.is_empty() { None } else { Some(s) }
 }
 
-#[allow(dead_code)]
-pub fn _run(_args: Args, config: &RootConfig) -> miette::Result<()> {
+pub fn run(_args: Args, config: &RootConfig) -> miette::Result<()> {
     let Some(scope) = config.protocol.scope.clone() else {
         return Err(miette::miette!("No scope found in trix.toml"));
     };


### PR DESCRIPTION
## Summary
- The `publish` command was gated behind `#[cfg(feature = "unstable")]` and hidden via `#[command(hide = true)]`, so the shipped (v0.23.0) binary always errored with *"The publish command is currently unstable and requires the \`unstable\` feature to be enabled."*
- Removes the cfg gate, deletes the now-dead `unstable` feature in `Cargo.toml`, and unhides the subcommand from `--help`.

## Test plan
- [ ] `cargo build` clean (verified locally)
- [ ] `trix publish --help` shows up in top-level help
- [ ] `trix publish` in a configured project runs the publish flow instead of erroring on the feature gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)