### PR TITLE
fix: drop nested block_on in publish, await OCI push directly

### DIFF
--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -38,7 +38,7 @@ fn capture_commit_sha() -> Option<String> {
     if s.is_empty() { None } else { Some(s) }
 }
 
-pub fn run(_args: Args, config: &RootConfig) -> miette::Result<()> {
+pub async fn run(_args: Args, config: &RootConfig) -> miette::Result<()> {
     let Some(scope) = config.protocol.scope.clone() else {
         return Err(miette::miette!("No scope found in trix.toml"));
     };
@@ -191,14 +191,16 @@ pub fn run(_args: Args, config: &RootConfig) -> miette::Result<()> {
     let image_reference = oci::reference_for(&registry_url, &protocol_ref)?;
     let oci_client = oci::client_for(&registry_url);
 
-    let digest = futures::executor::block_on(oci_client.push(
-        &image_reference,
-        &image_layers,
-        image_config,
-        &oci_client::secrets::RegistryAuth::Anonymous,
-        Some(image_manifest),
-    ))
-    .into_diagnostic()?;
+    let digest = oci_client
+        .push(
+            &image_reference,
+            &image_layers,
+            image_config,
+            &oci_client::secrets::RegistryAuth::Anonymous,
+            Some(image_manifest),
+        )
+        .await
+        .into_diagnostic()?;
 
     println!("Image pushed successfully!");
     println!("Image URL: {}", get_image_url(config));

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ async fn run_scoped_command(cli: Cli, config: RootConfig) -> Result<()> {
         Commands::Build(args) => cmds::build::run(args, &config, &profile),
         Commands::Identities(args) => cmds::identities::run(args, &config, &profile),
         Commands::Profile(args) => cmds::profile::run(args, &config, &profile),
-        Commands::Publish(args) => cmds::publish::run(args, &config),
+        Commands::Publish(args) => cmds::publish::run(args, &config).await,
         Commands::Use(args) => cmds::use_cmd::run(args, &config, &profile),
         Commands::Telemetry(args) => cmds::telemetry::run(args),
     };


### PR DESCRIPTION
## Summary

`publish::run` was synchronous and bridged into async via `futures::executor::block_on(oci_client.push(...))` while the outer `#[tokio::main]` runtime was already active. The inner futures-executor keeps polling reqwest's `PendingRequest` without yielding to tokio's reactor — it busy-spins, never letting the I/O complete.

Small text layers (source / TII / README) finished the HTTP round-trip fast enough to mask the bug. The 24 KB PNG logo layer added in #115 pushes the chunked-upload path past that window and the command hangs indefinitely.

Fix: make `publish::run` async (matching `codegen::run`) and `.await` the OCI push on the existing tokio runtime. `publish` now completes in seconds against `oci.tx3.land`.

## Test plan

- [x] Local publish of `protocols/acme/hydra-heads` (with a logo) against `oci.tx3.land` completes in seconds and the resulting manifest contains the expected four layers (source / TII / README / PNG)
- [ ] Publish a logo-less protocol — still completes (regression check)
- [ ] `cargo test --lib` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)