### PR TITLE
feat: consumer bootstrap on use, codegen --plugin, walk-up trix.toml

### DIFF
--- a/src/commands/codegen.rs
+++ b/src/commands/codegen.rs
@@ -1,6 +1,10 @@
-use std::path::PathBuf;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
 
-use crate::config::{CodegenPluginConfig, ProfileConfig, RootConfig};
+use crate::config::{
+    CodegenConfig, CodegenPlugin, CodegenPluginConfig, KNOWN_CODEGEN_PLUGINS, KnownCodegenPlugin,
+    ProfileConfig, RootConfig,
+};
 use clap::Args as ClapArgs;
 use miette::IntoDiagnostic;
 use reqwest::Client;
@@ -8,7 +12,22 @@ use tempfile::TempDir;
 use zip::ZipArchive;
 
 #[derive(ClapArgs, Debug)]
-pub struct Args {}
+pub struct Args {
+    /// Codegen plugin to use, e.g. `ts-client`, `rust-client`,
+    /// `python-client`, `go-client`. If no `[[codegen]]` entry exists for
+    /// this plugin yet, one is appended to `trix.toml` before generation
+    /// runs. With this flag, `trix codegen` is the only path that needs
+    /// to know plugin names; hand-editing `trix.toml` stays supported for
+    /// custom plugins and bespoke `output_dir`s.
+    #[arg(long, value_name = "NAME")]
+    pub plugin: Option<String>,
+
+    /// Generate without persisting a newly-seeded `[[codegen]]` entry
+    /// back to `trix.toml`. Intended for CI / one-shot scripts that emit
+    /// bindings without mutating the project file.
+    #[arg(long)]
+    pub no_save: bool,
+}
 
 async fn extract_github_templates(
     github_url: &str,
@@ -145,7 +164,93 @@ fn collect_codegen_targets(config: &RootConfig) -> miette::Result<Vec<(String, P
     Ok(targets)
 }
 
-pub async fn run(_args: Args, config: &RootConfig, _profile: &ProfileConfig) -> miette::Result<()> {
+/// Resolve which plugin (if any) the user requested for this invocation,
+/// either through `--plugin <name>` or — when no `[[codegen]]` is configured
+/// and stdin is a TTY — an interactive prompt. Returns `None` when the
+/// project already has at least one target and the user passed no flag
+/// (i.e. the existing non-interactive behavior).
+fn resolve_requested_plugin(
+    explicit: Option<&str>,
+    config: &RootConfig,
+) -> miette::Result<Option<KnownCodegenPlugin>> {
+    if let Some(name) = explicit {
+        let plugin: KnownCodegenPlugin = name.parse().map_err(|e: String| miette::miette!("{e}"))?;
+        return Ok(Some(plugin));
+    }
+
+    if !config.codegen.is_empty() {
+        return Ok(None);
+    }
+
+    if !std::io::stdin().is_terminal() {
+        return Err(miette::miette!(
+            "no [[codegen]] targets configured; pass --plugin <{}> to seed one",
+            KNOWN_CODEGEN_PLUGINS
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>()
+                .join("|")
+        ));
+    }
+
+    let choice = inquire::Select::new(
+        "Generate bindings for:",
+        KNOWN_CODEGEN_PLUGINS.to_vec(),
+    )
+    .prompt()
+    .into_diagnostic()?;
+
+    Ok(Some(choice))
+}
+
+/// Seed-if-absent: if `config` has no `[[codegen]]` entry matching `plugin`,
+/// append a minimal one and persist (unless `no_save`). Returns the
+/// possibly-mutated config to use for the rest of the run. Comparison goes
+/// through the enum so the verbose `KnownOrCustom::Known` form in TOML still
+/// dedups against the short form.
+fn seed_plugin_if_absent(
+    mut config: RootConfig,
+    plugin: KnownCodegenPlugin,
+    config_path: &Path,
+    no_save: bool,
+) -> miette::Result<RootConfig> {
+    let already = config.codegen.iter().any(|c| match c.plugin {
+        CodegenPlugin::Known(known) => std::mem::discriminant(&known) == std::mem::discriminant(&plugin),
+        CodegenPlugin::Custom(_) => false,
+    });
+
+    if already {
+        return Ok(config);
+    }
+
+    config.codegen.push(CodegenConfig {
+        plugin: CodegenPlugin::Known(plugin),
+        job_id: None,
+        output_dir: None,
+        options: None,
+    });
+
+    if !no_save {
+        config.save(&config_path.to_path_buf())?;
+        eprintln!("Added [[codegen]] plugin = \"{plugin}\" to trix.toml.");
+    }
+
+    Ok(config)
+}
+
+pub async fn run(
+    args: Args,
+    config: &RootConfig,
+    config_path: &Path,
+    _profile: &ProfileConfig,
+) -> miette::Result<()> {
+    let requested = resolve_requested_plugin(args.plugin.as_deref(), config)?;
+    let config = match requested {
+        Some(plugin) => seed_plugin_if_absent(config.clone(), plugin, config_path, args.no_save)?,
+        None => config.clone(),
+    };
+    let config = &config;
+
     crate::interfaces::validate(config)?;
     crate::interfaces::restore_all(config)?;
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -91,6 +91,51 @@ fn apply(config: RootConfig, devnet: Option<crate::devnet::Config>) -> miette::R
     Ok(())
 }
 
+/// Consumer-shape default config: a project that intends to *use* protocols
+/// rather than author one. Differs from [`default_config`] in that it omits
+/// the owner scope (consumers never publish) and starts with no codegen
+/// targets — `trix codegen --plugin <name>` seeds them on demand.
+fn consumer_default_config() -> RootConfig {
+    RootConfig {
+        protocol: ProtocolConfig {
+            name: infer_project_name(),
+            scope: None,
+            version: "0.1.0".into(),
+            description: None,
+            main: "main.tx3".into(),
+            readme: None,
+            logo: None,
+            repository: None,
+        },
+        ledger: LedgerConfig {
+            family: KnownLedgerFamily::Cardano,
+        },
+        codegen: Vec::new(),
+        profiles: NamedMap::default(),
+        networks: NamedMap::default(),
+        registry: None,
+        interfaces: NamedMap::default(),
+    }
+}
+
+/// Create a minimal consumer-shape project in the current directory. Writes
+/// only `trix.toml` — no `main.tx3`, no `tests/`, no `devnet.toml` — and
+/// prints a one-line notice so the side effect is visible. Returns the
+/// freshly-written config alongside the path it was saved to, so the caller
+/// can save further mutations (e.g. an `[interfaces.*]` pin from `trix use`)
+/// back to the same file.
+pub fn bootstrap_consumer_project() -> miette::Result<(RootConfig, PathBuf)> {
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let trix_toml = cwd.join("trix.toml");
+
+    let config = consumer_default_config();
+    config.save(&trix_toml)?;
+
+    eprintln!("No trix project found — created trix.toml here.");
+
+    Ok((config, trix_toml))
+}
+
 fn default_config() -> RootConfig {
     RootConfig {
         protocol: ProtocolConfig {

--- a/src/commands/use_cmd/mod.rs
+++ b/src/commands/use_cmd/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Args as ClapArgs, ValueEnum};
 
 use crate::config::{ProfileConfig, RootConfig};
@@ -5,6 +7,26 @@ use crate::interfaces::{self, AddRequest, TrustPolicy};
 use crate::refs::ProtocolRef;
 
 mod view;
+
+/// Resolve the project that `trix use` will pin into. If `load_config`
+/// already found a `trix.toml` up the tree, use that; otherwise bootstrap a
+/// consumer-shape project in the current directory — unless `--no-init`
+/// turns the absence into a hard error. Keeps the bootstrap decision inside
+/// the command that triggers it, so main.rs can dispatch uniformly.
+pub fn ensure_project(
+    loaded: Option<(RootConfig, PathBuf)>,
+    args: &Args,
+) -> miette::Result<(RootConfig, PathBuf)> {
+    if let Some(found) = loaded {
+        return Ok(found);
+    }
+    if args.no_init {
+        return Err(miette::miette!(
+            "No trix.toml found and --no-init was passed; nothing to do"
+        ));
+    }
+    crate::commands::init::bootstrap_consumer_project()
+}
 
 /// The verification tier a `trix use` invocation requires. Today only
 /// `oidc` is meaningful as a *requirement* (the App tier is a strictly

--- a/src/commands/use_cmd/mod.rs
+++ b/src/commands/use_cmd/mod.rs
@@ -55,9 +55,20 @@ pub struct Args {
     /// verifier records previous subjects to compare against.
     #[arg(long)]
     pub accept_rename: bool,
+
+    /// Refuse to auto-bootstrap a consumer project when no `trix.toml` is
+    /// found. Use in CI or scripted setups where a missing project
+    /// indicates a configuration mistake rather than an empty workspace.
+    #[arg(long)]
+    pub no_init: bool,
 }
 
-pub fn run(args: Args, config: &RootConfig, _profile: &ProfileConfig) -> miette::Result<()> {
+pub fn run(
+    args: Args,
+    config: &RootConfig,
+    _config_path: &std::path::Path,
+    _profile: &ProfileConfig,
+) -> miette::Result<()> {
     let dry_run = args.dry_run;
 
     if args.insecure && args.require.is_some() {

--- a/src/config/convention.rs
+++ b/src/config/convention.rs
@@ -249,6 +249,56 @@ pub const KNOWN_CODEGEN_PLUGINS: &[KnownCodegenPlugin] = &[
     KnownCodegenPlugin::GoClient,
 ];
 
+impl KnownCodegenPlugin {
+    /// Single-word substring → plugin suggestion for the `did you mean`
+    /// message on an unknown `--plugin` value. Deliberately small and
+    /// hand-rolled: keeps the list of "fuzzy synonyms" auditable instead
+    /// of relying on edit-distance scoring that can swing oddly between
+    /// short kebab-case names.
+    fn suggest(input: &str) -> Option<KnownCodegenPlugin> {
+        let lower = input.to_lowercase();
+        if lower.contains("typescript")
+            || lower.contains("javascript")
+            || lower == "ts"
+            || lower == "js"
+            || lower == "node"
+        {
+            Some(KnownCodegenPlugin::TsClient)
+        } else if lower.contains("rust") || lower == "rs" {
+            Some(KnownCodegenPlugin::RustClient)
+        } else if lower.contains("python") || lower == "py" {
+            Some(KnownCodegenPlugin::PythonClient)
+        } else if lower.contains("golang") || lower == "go" {
+            Some(KnownCodegenPlugin::GoClient)
+        } else {
+            None
+        }
+    }
+}
+
+impl std::str::FromStr for KnownCodegenPlugin {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        for plugin in KNOWN_CODEGEN_PLUGINS {
+            if plugin.to_string() == s {
+                return Ok(*plugin);
+            }
+        }
+        let available = KNOWN_CODEGEN_PLUGINS
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let suggestion = KnownCodegenPlugin::suggest(s)
+            .map(|p| format!(" — did you mean '{p}'?"))
+            .unwrap_or_default();
+        Err(format!(
+            "unknown plugin '{s}'{suggestion} (available: {available})"
+        ))
+    }
+}
+
 impl std::fmt::Display for KnownCodegenPlugin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
@@ -423,6 +473,28 @@ mod tests {
         let config: RootConfig = toml::from_str(toml).unwrap();
         assert!(config.registry.is_none());
         assert_eq!(config.registry_url(), DEFAULT_REGISTRY_URL);
+    }
+
+    #[test]
+    fn plugin_from_str_roundtrips_kebab_case() {
+        for plugin in KNOWN_CODEGEN_PLUGINS {
+            let parsed: KnownCodegenPlugin = plugin.to_string().parse().unwrap();
+            assert_eq!(parsed.to_string(), plugin.to_string());
+        }
+    }
+
+    #[test]
+    fn plugin_from_str_suggests_close_alias() {
+        let err: String = "typescript".parse::<KnownCodegenPlugin>().unwrap_err();
+        assert!(err.contains("ts-client"), "no suggestion in: {err}");
+        assert!(err.contains("available:"));
+    }
+
+    #[test]
+    fn plugin_from_str_lists_available_when_no_suggestion() {
+        let err: String = "zzz".parse::<KnownCodegenPlugin>().unwrap_err();
+        assert!(!err.contains("did you mean"));
+        assert!(err.contains("ts-client") && err.contains("rust-client"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,16 +34,6 @@ fn run_global_command(cli: Cli) -> Result<()> {
     match cli.command {
         Commands::Init(args) => cmds::init::run(args, None),
         Commands::Telemetry(args) => cmds::telemetry::run(args),
-        Commands::Use(args) => {
-            if args.no_init {
-                return Err(miette::miette!(
-                    "No trix.toml found and --no-init was passed; nothing to do"
-                ));
-            }
-            let (config, path) = cmds::init::bootstrap_consumer_project()?;
-            let profile = config.resolve_profile(&cli.profile)?;
-            cmds::use_cmd::run(args, &config, &path, &profile)
-        }
         _ => Err(miette::miette!("No trix.toml found in current directory")),
     }
 }
@@ -97,6 +87,16 @@ async fn main() -> Result<()> {
     if global_config.telemetry.enabled {
         telemetry::initialize_telemetry(&global_config.telemetry)?;
     }
+
+    // `trix use` is the one command that can fabricate the project it
+    // operates on. Resolve that here so the scoped/global dispatch below
+    // stays uniform — every other command sees the same loaded state it
+    // would have seen without `use`.
+    let loaded = if let Commands::Use(args) = &cli.command {
+        Some(cmds::use_cmd::ensure_project(loaded, args)?)
+    } else {
+        loaded
+    };
 
     match loaded {
         Some((config, path)) => run_scoped_command(cli, config, path).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 
 use trix::{
@@ -8,29 +10,45 @@ use trix::{
 };
 use miette::{IntoDiagnostic as _, Result};
 
-pub fn load_config() -> Result<Option<RootConfig>> {
-    let current_dir = std::env::current_dir().into_diagnostic()?;
+/// Walk up parent directories looking for a `trix.toml`, matching the same
+/// convention as `dirs::protocol_root`. Returns the loaded config and the
+/// on-disk path so callers (e.g. `trix codegen`) can save back to the same
+/// file regardless of cwd.
+pub fn load_config() -> Result<Option<(RootConfig, PathBuf)>> {
+    let mut cwd = std::env::current_dir().into_diagnostic()?;
 
-    let config_path = current_dir.join("trix.toml");
-
-    if !config_path.exists() {
-        return Ok(None);
+    loop {
+        let candidate = cwd.join("trix.toml");
+        if candidate.exists() {
+            let config = RootConfig::load(&candidate)?;
+            return Ok(Some((config, candidate)));
+        }
+        match cwd.parent() {
+            Some(parent) => cwd = parent.to_path_buf(),
+            None => return Ok(None),
+        }
     }
-
-    let config = RootConfig::load(&config_path)?;
-
-    Ok(Some(config))
 }
 
 fn run_global_command(cli: Cli) -> Result<()> {
     match cli.command {
         Commands::Init(args) => cmds::init::run(args, None),
         Commands::Telemetry(args) => cmds::telemetry::run(args),
+        Commands::Use(args) => {
+            if args.no_init {
+                return Err(miette::miette!(
+                    "No trix.toml found and --no-init was passed; nothing to do"
+                ));
+            }
+            let (config, path) = cmds::init::bootstrap_consumer_project()?;
+            let profile = config.resolve_profile(&cli.profile)?;
+            cmds::use_cmd::run(args, &config, &path, &profile)
+        }
         _ => Err(miette::miette!("No trix.toml found in current directory")),
     }
 }
 
-async fn run_scoped_command(cli: Cli, config: RootConfig) -> Result<()> {
+async fn run_scoped_command(cli: Cli, config: RootConfig, config_path: PathBuf) -> Result<()> {
     let profile = config.resolve_profile(&cli.profile)?;
 
     let metric = telemetry::track_command_execution(&cli);
@@ -40,7 +58,7 @@ async fn run_scoped_command(cli: Cli, config: RootConfig) -> Result<()> {
         Commands::Invoke(args) => cmds::invoke::run(args, &config, &profile),
         Commands::Devnet(args) => cmds::devnet::run(args, &config, &profile),
         Commands::Explore(args) => cmds::explore::run(args, &config, &profile),
-        Commands::Codegen(args) => cmds::codegen::run(args, &config, &profile).await,
+        Commands::Codegen(args) => cmds::codegen::run(args, &config, &config_path, &profile).await,
         Commands::Check(args) => cmds::check::run(args, &config, &profile),
         Commands::Inspect(args) => cmds::inspect::run(args, &config),
         Commands::Test(args) => cmds::test::run(args, &config, &profile),
@@ -48,7 +66,7 @@ async fn run_scoped_command(cli: Cli, config: RootConfig) -> Result<()> {
         Commands::Identities(args) => cmds::identities::run(args, &config, &profile),
         Commands::Profile(args) => cmds::profile::run(args, &config, &profile),
         Commands::Publish(args) => cmds::publish::run(args, &config).await,
-        Commands::Use(args) => cmds::use_cmd::run(args, &config, &profile),
+        Commands::Use(args) => cmds::use_cmd::run(args, &config, &config_path, &profile),
         Commands::Telemetry(args) => cmds::telemetry::run(args),
     };
 
@@ -72,7 +90,7 @@ async fn main() -> Result<()> {
     // Check for updates silently
     let _ = updates::check_for_updates();
 
-    let config = load_config()?;
+    let loaded = load_config()?;
 
     let global_config = global::ensure_global_config()?;
 
@@ -80,8 +98,8 @@ async fn main() -> Result<()> {
         telemetry::initialize_telemetry(&global_config.telemetry)?;
     }
 
-    match config {
-        Some(config) => run_scoped_command(cli, config).await,
+    match loaded {
+        Some((config, path)) => run_scoped_command(cli, config, path).await,
         None => run_global_command(cli),
     }
 }


### PR DESCRIPTION
## Summary

Two friction points removed from the consumer flow:

- **`trix use` auto-bootstraps a consumer-shape project** when no `trix.toml` is found in cwd or any ancestor. The bootstrap writes only `trix.toml` (no `main.tx3`, no `tests/`, no owner scope) — the consumer shape, distinct from the authoring shape that `trix init` still produces. `--no-init` opts out for CI / strict workflows.
- **`trix codegen` owns codegen targets.** A new `--plugin <name>` flag seeds a `[[codegen]]` entry if one is missing for that plugin and persists it to `trix.toml` before generating. `--no-save` keeps the side-effect-free path. With no targets and no flag, codegen prompts interactively on a TTY and errors with a pointer at `--plugin` otherwise.
- `KnownCodegenPlugin` gets a `FromStr` impl with a friendly "did you mean 'ts-client'?" suggestion. Unknown plugin names fail before any codegen runs — never seed a bogus `[[codegen]]` entry.
- `load_config` walks up the directory tree for `trix.toml` (matching `dirs::protocol_root`), so every command works from a subdirectory and returns the on-disk path so codegen can save back to it from anywhere.

Together with PRs in the SDK repos (which add `README.md.hbs` per plugin) and docs/registry updates, this is the new consumer flow:

```sh
trix use acme/transfer
trix codegen --plugin ts-client
```

No flexibility is removed: `[[codegen]]`, multiple targets, custom `output_dir`, custom plugins, and registry overrides all stay reachable.

## Test plan

- [x] `cargo test --lib` — 42/42 pass, including 3 new `KnownCodegenPlugin::from_str` tests (roundtrip, suggest close alias, list available when no suggestion)
- [ ] In an empty dir: `trix use tx3-lang/faucet@latest` creates `trix.toml` with `[protocol]`, `[ledger]`, `[interfaces.faucet]` only — no `main.tx3` or `tests/`
- [ ] Running `trix use` from a subdirectory pins into the ancestor's `trix.toml` rather than creating a nested project
- [ ] `trix codegen --plugin ts-client` appends `[[codegen]]` to `trix.toml` and emits output; second run with the same flag is a no-op for config
- [ ] `trix codegen --plugin typescript` fails with the "did you mean 'ts-client'?" message and leaves `trix.toml` untouched
- [ ] `trix codegen --plugin rust-client --no-save` generates without modifying `trix.toml`
- [ ] Bare `trix codegen` with no targets prompts on a TTY; with stdin redirected, errors pointing at `--plugin`
- [ ] `trix use --no-init` in an empty dir errors instead of bootstrapping