### PR TITLE
fix(use): accept image/png logo layer when pulling protocol images

### DIFF
--- a/src/interfaces/oci.rs
+++ b/src/interfaces/oci.rs
@@ -114,10 +114,6 @@ pub async fn pull(
     client: &oci_client::Client,
     reference: &oci_client::Reference,
 ) -> Result<PulledArtifact> {
-    // Include LOGO_PNG_MEDIA_TYPE so the OCI client doesn't reject images
-    // that carry a logo layer attached by `trix publish`. The layer body is
-    // not consumed by `trix use` (the logo is for the registry frontend);
-    // it falls through the `_ => {}` arm below.
     let accepted = vec![
         PROTOCOL_MEDIA_TYPE,
         TII_MEDIA_TYPE,

--- a/src/interfaces/oci.rs
+++ b/src/interfaces/oci.rs
@@ -114,7 +114,16 @@ pub async fn pull(
     client: &oci_client::Client,
     reference: &oci_client::Reference,
 ) -> Result<PulledArtifact> {
-    let accepted = vec![PROTOCOL_MEDIA_TYPE, TII_MEDIA_TYPE, MARKDOWN_MEDIA_TYPE];
+    // Include LOGO_PNG_MEDIA_TYPE so the OCI client doesn't reject images
+    // that carry a logo layer attached by `trix publish`. The layer body is
+    // not consumed by `trix use` (the logo is for the registry frontend);
+    // it falls through the `_ => {}` arm below.
+    let accepted = vec![
+        PROTOCOL_MEDIA_TYPE,
+        TII_MEDIA_TYPE,
+        MARKDOWN_MEDIA_TYPE,
+        LOGO_PNG_MEDIA_TYPE,
+    ];
     let image = client
         .pull(
             reference,


### PR DESCRIPTION
## Summary

`trix publish` attaches an `image/png` logo layer to published protocol images (see `design/005-protocol-logos.md`), but the pull path passed `oci_client::pull` an `accepted` list of just the three protocol layer media types (`application/tx3`, `application/tii+json`, `text/markdown`). The `oci-client` crate rejects any layer whose media type isn't in `accepted`, so `trix use` failed on every protocol that ships with a logo:

\`\`\`
$ trix use open-tx3/vyfi:0.1.0
Error: Incompatible layer media type: image/png
\`\`\`

Adds `LOGO_PNG_MEDIA_TYPE` to the accepted list. The existing `_ => {}` arm in the layer-dispatch match already silently drops layers it doesn't care about, so the logo bytes are discarded — `trix use` is consumer-side and doesn't need them; the logo is only for the registry frontend.

## Test plan

- [x] Repro before the fix: `trix use open-tx3/vyfi:0.1.0` fails with the media-type error
- [x] After the fix: pulls successfully, pins `vyfi:0.1.0` to `trix.toml`, lists the four transactions (`add_liquidity`, `remove_liquidity`, `swap_a_to_b`, `swap_b_to_a`)
- [ ] Sanity check on a protocol *without* a logo (e.g. one of the in-tree examples) still pulls cleanly