### PR TITLE
fix(publish): lowercase OCI repository path for uppercase scopes

### DIFF
--- a/src/interfaces/oci.rs
+++ b/src/interfaces/oci.rs
@@ -92,8 +92,19 @@ pub fn reference_for(
     };
     let tag = version.unwrap_or("latest");
     let host = registry_host(registry_url);
-    oci_client::Reference::try_from(format!("{}/{}/{}:{}", host, scope, name, tag))
-        .into_diagnostic()
+    // OCI repository paths must be lowercase, but `scope` doubles as the
+    // GitHub owner (e.g. "SundaeSwap-finance") which legitimately carries
+    // capitals. Lowercase only the path segments here so registry addressing
+    // stays OCI-compliant while the original-case scope is preserved for
+    // identity/metadata everywhere else. Tags allow uppercase, so leave `tag`.
+    oci_client::Reference::try_from(format!(
+        "{}/{}/{}:{}",
+        host,
+        scope.to_lowercase(),
+        name.to_lowercase(),
+        tag
+    ))
+    .into_diagnostic()
 }
 
 /// Result of a successful pull. Bytes are owned so the caller can write them
@@ -168,4 +179,35 @@ pub async fn pull(
         metadata,
         digest,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_lowercases_scope_and_name_for_oci_compliance() {
+        // `scope` mirrors the GitHub owner, which may carry capitals (e.g.
+        // "SundaeSwap-finance"). OCI repository paths must be lowercase, so the
+        // reference is lowercased while identity/metadata keep the original case.
+        let protocol_ref = ProtocolRef::Registry {
+            scope: "SundaeSwap-finance".to_string(),
+            name: "Sundae-V3".to_string(),
+            version: Some("0.1.0".to_string()),
+        };
+        let reference = reference_for("https://registry.tx3.dev", &protocol_ref).unwrap();
+        assert_eq!(reference.repository(), "sundaeswap-finance/sundae-v3");
+        assert_eq!(reference.tag(), Some("0.1.0"));
+    }
+
+    #[test]
+    fn reference_defaults_missing_version_to_latest() {
+        let protocol_ref = ProtocolRef::Registry {
+            scope: "txpipe".to_string(),
+            name: "faucet".to_string(),
+            version: None,
+        };
+        let reference = reference_for("https://registry.tx3.dev", &protocol_ref).unwrap();
+        assert_eq!(reference.tag(), Some("latest"));
+    }
 }


### PR DESCRIPTION
## Problem

`trix publish` rejects protocols whose `[protocol].scope` carries capitals, e.g.:

```toml
[protocol]
name = "sundae-v3"
scope = "SundaeSwap-finance"
version = "0.1.0"
```

The metadata passes config loading and `validate_ident` (which accepts `[a-zA-Z]`), but the publish fails at push time. `scope` deliberately mirrors the **GitHub org owner** — `publish.rs` verifies it case-sensitively against the `[protocol].repository` URL owner, and GitHub orgs legitimately have capitals. So we can't simply reject capitals.

The real issue: `reference_for` (`src/interfaces/oci.rs`) built the OCI reference with the original-case scope/name, and the **OCI image spec requires repository paths to be lowercase** — `oci_client::Reference::try_from` rejected it.

## Fix

Lowercase only the two repository path segments in `reference_for`, the single chokepoint shared by both `trix publish` (push) and `trix use` (pull). This keeps registry addressing OCI-compliant and consistent across both paths, while the original-case scope is preserved everywhere else (GitHub verification, image metadata, the `org.opencontainers.image.vendor` annotation). Tags are left untouched since OCI permits uppercase there.

Adds regression tests covering the lowercasing (`SundaeSwap-finance`/`Sundae-V3` → `sundaeswap-finance/sundae-v3`) and the `latest` default.

## Follow-up to confirm (registry side, out of this repo)

If the registry's push-authorization compares the GitHub OIDC owner case-sensitively against the lowercased repository path segment, a publisher from org `SundaeSwap-finance` could still fail authorization. Worth verifying the registry resolves that case-insensitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)