### PR TITLE
chore: raise tx3c compat floor to 0.22.0

### DIFF
--- a/src/spawn/compat.rs
+++ b/src/spawn/compat.rs
@@ -29,11 +29,13 @@ struct Compat {
 }
 
 const COMPAT_MATRIX: &[Compat] = &[
-    // 0.18.0 introduced `decode`, `--emit tir-json`, `--diagnostics-format`
-    // (0.17.0 was cut before that surface existed).
+    // 0.22.0 introduced parametric tuple types: tx3c now emits TIR carrying the
+    // `Tuple` type/expression variants, a forward-incompatible addition that
+    // pre-0.22 readers cannot decode. Pin the floor here so the TIR `trix`
+    // consumes always matches the schema it supports.
     Compat {
         tool: "tx3c",
-        min: "0.18.0",
+        min: "0.22.0",
     },
 ];
 


### PR DESCRIPTION
## Summary

Raises the built-in `tx3c` compatibility floor in `COMPAT_MATRIX` from `0.18.0` to `0.22.0`.

tx3c 0.22.0 introduced **parametric tuple types**: it emits TIR carrying the `Tuple` type/expression variants, a forward-incompatible addition that pre-0.22 readers cannot decode. Pinning the floor at 0.22.0 ensures `trix` drives a tuple-capable compiler, so the TIR it consumes always matches the schema it supports.

Per-project `[toolchain] tx3c` minimums continue to raise this floor further; this only moves the global lower bound.

## Verification

Builds clean; `compat` unit tests pass (the test fixtures exercise `evaluate()` boundary logic against a local matrix value and are unaffected by the production floor change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)