### PR TITLE
fix(test): repair `trix test` expect/balance phase + modernize utxorpc utxo parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,6 +4422,7 @@ dependencies = [
  "anyhow",
  "askama",
  "assert_cmd",
+ "base64 0.22.1",
  "bip39",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
  "pallas-traverse",
  "pallas-validate",
  "prost-types",
- "utxorpc-spec 0.18.1",
+ "utxorpc-spec",
 ]
 
 [[package]]
@@ -4422,7 +4422,6 @@ dependencies = [
  "anyhow",
  "askama",
  "assert_cmd",
- "base64 0.22.1",
  "bip39",
  "chrono",
  "clap",
@@ -4563,31 +4562,15 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utxorpc"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60b6baab3e86e71acf144ebfe97263f22eddcf2707d19fca5ffdaeeea95e96f"
+checksum = "6a7693fb6cd3db60ea90f87a4445d0fc572dd8bbdb541fc68a32337c0a275e44"
 dependencies = [
  "bytes",
  "thiserror 2.0.17",
  "tokio",
  "tonic",
- "utxorpc-spec 0.17.0",
-]
-
-[[package]]
-name = "utxorpc-spec"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d984ee351b308377e118135e638a5d544fdb0855f12a3b088d9dcaf0432052"
-dependencies = [
- "bytes",
- "futures-core",
- "pbjson",
- "pbjson-types",
- "prost",
- "prost-types",
- "serde",
- "tonic",
+ "utxorpc-spec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ dirs = "6.0.0"
 serde_json = "1.0.140"
 cryptoxide = "0.5.0"
 hex = { version = "0.4.3", features = ["serde"] }
+base64 = "0.22"
 handlebars = "6.3.2"
 reqwest = { version = "0.12.15", features = ["json"] }
 tempfile = "3.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/tx3-lang/trix"
 # delegated to the `tx3c` binary via `spawn::tx3c`, so `trix` links no
 # `tx3-*` crate and its version is decoupled from the toolchain's.
 
-utxorpc = "0.12.0"
+utxorpc = "0.13.0"
 # utxorpc = { git = "https://github.com/utxorpc/rust-sdk.git" }
 # utxorpc = { path = "../../utxorpc/rust-sdk" }
 
@@ -35,7 +35,6 @@ dirs = "6.0.0"
 serde_json = "1.0.140"
 cryptoxide = "0.5.0"
 hex = { version = "0.4.3", features = ["serde"] }
-base64 = "0.22"
 handlebars = "6.3.2"
 reqwest = { version = "0.12.15", features = ["json"] }
 tempfile = "3.10"

--- a/src/commands/expect.rs
+++ b/src/commands/expect.rs
@@ -7,17 +7,28 @@ use crate::spawn::cshell;
 // Import Expect types from the `test` module
 use crate::commands::test::ExpectUtxo;
 
+/// Resolve a `from` party reference to a cshell wallet name.
+///
+/// Expectations name their party with the same `@`-prefixed placeholder the
+/// transactions use (e.g. `@bob`), but cshell wallets are named without the
+/// prefix (`bob`). The transaction path strips it in
+/// `test::replace_placeholder_args`; the expect path must do the same before
+/// querying utxos, or cshell errors with `failed to get wallet utxos`.
+fn wallet_name(from: &str) -> &str {
+    from.trim_start_matches('@')
+}
+
 /// Run all checks for a slice of `ExpectUtxo` expectations.
 /// Returns `Ok(true)` when any expectation failed, `Ok(false)` when all passed.
 ///
 ///
-pub fn expect_utxo(expects: &[ExpectUtxo], test_home: &Path) -> Result<bool> {
+pub fn expect_utxo(expects: &[ExpectUtxo], test_home: &Path, provider: &str) -> Result<bool> {
     let mut failed_any = false;
 
     for expect in expects.iter() {
         let mut failed = false;
 
-        let utxos = cshell::wallet_utxos(test_home, &expect.from)?;
+        let utxos = cshell::wallet_utxos(test_home, wallet_name(&expect.from), provider)?;
 
         if expect.datum_equals.is_none() && expect.min_amount.is_empty() {
             if utxos.is_empty() {
@@ -100,4 +111,21 @@ pub fn expect_utxo(expects: &[ExpectUtxo], test_home: &Path) -> Result<bool> {
     }
 
     Ok(failed_any)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wallet_name;
+
+    #[test]
+    fn wallet_name_strips_at_prefix() {
+        // The expect path must query the bare wallet name `bob`, not the
+        // `@bob` placeholder cshell can't resolve.
+        assert_eq!(wallet_name("@bob"), "bob");
+    }
+
+    #[test]
+    fn wallet_name_passes_through_bare_name() {
+        assert_eq!(wallet_name("bob"), "bob");
+    }
 }

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -194,21 +194,28 @@ pub fn run(args: Args, config: &RootConfig, profile: &ProfileConfig) -> Result<(
         sleep(Duration::from_secs(BLOCK_PRODUCTION_INTERVAL_SECONDS));
     }
 
-    failed |= crate::commands::expect::expect_utxo(&test.expect, &devnet.home)?;
+    // Query utxos from the cshell store that actually holds the wallets and the
+    // provider (`wallet.target_dir`) — the same home the invoke path submits
+    // against. `devnet.home` is the *dolos* store and has neither.
+    let provider = crate::wallet::provider_name(&profile.name);
+    let expect_outcome =
+        crate::commands::expect::expect_utxo(&test.expect, &wallet.target_dir, &provider);
 
-    if !failed {
-        println!("Test Passed\n");
-    }
-
+    // Tear down the devnet unconditionally — even when the expect phase errors,
+    // so a failed or early-exiting test never leaves a Dolos daemon running.
     devnet
         .daemon
         .kill()
         .into_diagnostic()
         .context("failed to stop dolos devnet in background")?;
 
+    failed |= expect_outcome?;
+
     if failed {
         bail!("Test failed, see output above for details.");
     }
+
+    println!("Test Passed\n");
 
     Ok(())
 }

--- a/src/spawn/cshell.rs
+++ b/src/spawn/cshell.rs
@@ -40,35 +40,154 @@ pub struct OutputBalance {
     pub coin: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+// Flat view of a wallet UTxO, holding just what the `expect` checks read:
+// lovelace, native assets, and the datum hash. Built from the cshell wire shape
+// below via `WireUtxo::into_utxo` — raw bytes are already base64-decoded here,
+// so callers `hex::encode`/`from_utf8` them directly.
+#[derive(Debug, Clone, PartialEq)]
 pub struct Asset {
-    #[serde(with = "hex::serde")]
     pub name: Vec<u8>,
     pub output_coin: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Datum {
-    #[serde(with = "hex::serde")]
     pub hash: Vec<u8>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UtxoAsset {
-    #[serde(with = "hex::serde")]
     pub policy_id: Vec<u8>,
     pub assets: Vec<Asset>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UTxO {
-    #[serde(with = "hex::serde")]
-    pub tx: Vec<u8>,
-    pub tx_index: u64,
-    pub address: String,
-    pub coin: String, // To avoid overflow
+    pub coin: String, // lovelace, kept as a string to sidestep overflow
     pub assets: Vec<UtxoAsset>,
     pub datum: Option<Datum>,
+}
+
+// ---- cshell `wallet utxos --output-format json` wire shape ----
+//
+// cshell emits utxorpc `AnyUtxoData` via pbjson: camelCase keys, `bytes` fields
+// as base64, the `parsed_state` oneof flattened to its variant name (`cardano`),
+// `uint64` as decimal strings, and `BigInt` as a nested oneof object
+// (e.g. `{ "int": "2000000" }`). We deserialize that shape directly rather than
+// reuse trix's `utxorpc` types, whose pinned spec models `coin` as a plain
+// `uint64` and so won't parse cshell's BigInt-shaped coin.
+
+#[derive(Debug, Deserialize)]
+struct WalletUtxosOutput {
+    #[serde(default)]
+    utxos: Vec<WireUtxo>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct WireUtxo {
+    // `parsed_state` oneof — the cardano variant carries everything we read.
+    #[serde(default)]
+    cardano: Option<WireCardano>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireCardano {
+    #[serde(default)]
+    coin: Option<WireBigInt>,
+    #[serde(default)]
+    assets: Vec<WireMultiasset>,
+    #[serde(default)]
+    datum: Option<WireDatum>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct WireBigInt {
+    // The plain `int` variant of utxorpc's BigInt oneof — lovelace fits here.
+    // The `bigUInt`/`bigNInt` byte variants don't occur for ADA amounts.
+    #[serde(default)]
+    int: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireMultiasset {
+    #[serde(default)]
+    policy_id: Option<String>,
+    #[serde(default)]
+    assets: Vec<WireAsset>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireAsset {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    output_coin: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct WireDatum {
+    #[serde(default)]
+    hash: Option<String>,
+}
+
+fn decode_b64(s: &str) -> miette::Result<Vec<u8>> {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+    STANDARD
+        .decode(s)
+        .into_diagnostic()
+        .context("decoding base64 bytes in cshell wallet utxos output")
+}
+
+impl WireUtxo {
+    fn into_utxo(self) -> miette::Result<UTxO> {
+        let cardano = self.cardano.unwrap_or_default();
+
+        let coin = cardano
+            .coin
+            .and_then(|b| b.int)
+            .unwrap_or_else(|| "0".to_string());
+
+        let mut assets = Vec::with_capacity(cardano.assets.len());
+        for multiasset in cardano.assets {
+            let policy_id = match multiasset.policy_id {
+                Some(policy) => decode_b64(&policy)?,
+                None => Vec::new(),
+            };
+
+            let mut inner = Vec::with_capacity(multiasset.assets.len());
+            for asset in multiasset.assets {
+                inner.push(Asset {
+                    name: match asset.name {
+                        Some(name) => decode_b64(&name)?,
+                        None => Vec::new(),
+                    },
+                    output_coin: asset.output_coin.unwrap_or_else(|| "0".to_string()),
+                });
+            }
+
+            assets.push(UtxoAsset {
+                policy_id,
+                assets: inner,
+            });
+        }
+
+        let datum = match cardano.datum.and_then(|d| d.hash) {
+            Some(hash) => Some(Datum {
+                hash: decode_b64(&hash)?,
+            }),
+            None => None,
+        };
+
+        Ok(UTxO {
+            coin,
+            assets,
+            datum,
+        })
+    }
 }
 
 pub struct Provider {
@@ -331,37 +450,43 @@ pub fn wallet_balance(home: &Path, wallet_name: &str) -> miette::Result<OutputBa
     serde_json::from_slice(&output.stdout).into_diagnostic()
 }
 
-pub fn wallet_utxos(home: &Path, wallet_name: &str) -> miette::Result<Vec<UTxO>> {
+pub fn wallet_utxos(home: &Path, wallet_name: &str, provider: &str) -> miette::Result<Vec<UTxO>> {
     let mut cmd = new_generic_command(home)?;
 
-    cmd.args(["wallet", "utxos", wallet_name, "--output-format", "json"]);
+    // `cshell wallet utxos <NAME> <PROVIDER>` — the provider is positional and
+    // falls back to cshell's *default* provider when omitted. The generated
+    // cshell.toml marks its single provider `is_default = false`, so the expect
+    // path must name it explicitly (the same one the invoke path submits to),
+    // or cshell errors with "Wallet and provider not found".
+    cmd.args([
+        "wallet",
+        "utxos",
+        wallet_name,
+        provider,
+        "--output-format",
+        "json",
+    ]);
 
     let output = cmd
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .output()
         .into_diagnostic()
         .context("running CShell wallet utxos")?;
 
     if !output.status.success() {
-        bail!("CShell failed to get wallet utxos");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "CShell failed to get wallet utxos for `{wallet_name}`: {}",
+            stderr.trim()
+        );
     }
 
-    match serde_json::from_slice::<Vec<UTxO>>(&output.stdout) {
-        Ok(list) => Ok(list),
-        Err(_) => {
-            let v: serde_json::Value = serde_json::from_slice(&output.stdout).into_diagnostic()?;
-            if let Some(utxos_val) = v.get("utxos") {
-                let list: Vec<UTxO> =
-                    serde_json::from_value(utxos_val.clone()).into_diagnostic()?;
-                Ok(list)
-            } else if v.is_array() {
-                let list: Vec<UTxO> = serde_json::from_value(v).into_diagnostic()?;
-                Ok(list)
-            } else {
-                bail!("unexpected CShell wallet balance output shape")
-            }
-        }
-    }
+    let parsed: WalletUtxosOutput = serde_json::from_slice(&output.stdout)
+        .into_diagnostic()
+        .context("parsing cshell wallet utxos output")?;
+
+    parsed.utxos.into_iter().map(WireUtxo::into_utxo).collect()
 }
 
 pub fn explorer(home: &Path, provider: &str) -> miette::Result<Child> {

--- a/src/spawn/cshell.rs
+++ b/src/spawn/cshell.rs
@@ -8,6 +8,7 @@ use askama::Template;
 
 use miette::{bail, Context as _, IntoDiagnostic as _};
 use serde::{de, Deserialize, Deserializer, Serialize};
+use utxorpc::spec::query::{any_utxo_data::ParsedState, AnyUtxoData};
 
 use crate::config::{TrpConfig, U5cConfig};
 
@@ -41,9 +42,9 @@ pub struct OutputBalance {
 }
 
 // Flat view of a wallet UTxO, holding just what the `expect` checks read:
-// lovelace, native assets, and the datum hash. Built from the cshell wire shape
-// below via `WireUtxo::into_utxo` — raw bytes are already base64-decoded here,
-// so callers `hex::encode`/`from_utf8` them directly.
+// lovelace, native assets, and the datum hash. Built from cshell's utxorpc
+// `AnyUtxoData` output via `flatten_utxo` — bytes are already decoded here, so
+// callers `hex::encode`/`from_utf8` them directly.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Asset {
     pub name: Vec<u8>,
@@ -68,125 +69,79 @@ pub struct UTxO {
     pub datum: Option<Datum>,
 }
 
-// ---- cshell `wallet utxos --output-format json` wire shape ----
-//
-// cshell emits utxorpc `AnyUtxoData` via pbjson: camelCase keys, `bytes` fields
-// as base64, the `parsed_state` oneof flattened to its variant name (`cardano`),
-// `uint64` as decimal strings, and `BigInt` as a nested oneof object
-// (e.g. `{ "int": "2000000" }`). We deserialize that shape directly rather than
-// reuse trix's `utxorpc` types, whose pinned spec models `coin` as a plain
-// `uint64` and so won't parse cshell's BigInt-shaped coin.
-
+// cshell `wallet utxos --output-format json` emits utxorpc `AnyUtxoData` wrapped
+// as `{ "utxos": [...] }`. We deserialize straight into the spec types (pbjson
+// handles the camelCase / base64 / oneof / BigInt-coin shaping) and flatten to
+// the view above. This requires `utxorpc` >= the spec rev that models cardano
+// `coin` as `BigInt` (>= 0.13 / spec 0.18); older revs typed it as plain
+// `uint64` and won't parse cshell's `{ "int": "..." }` coin.
 #[derive(Debug, Deserialize)]
 struct WalletUtxosOutput {
     #[serde(default)]
-    utxos: Vec<WireUtxo>,
+    utxos: Vec<AnyUtxoData>,
 }
 
-#[derive(Debug, Default, Deserialize)]
-struct WireUtxo {
-    // `parsed_state` oneof — the cardano variant carries everything we read.
-    #[serde(default)]
-    cardano: Option<WireCardano>,
+// Render a utxorpc `BigInt` as a decimal string. ADA/native amounts always
+// arrive as the plain `Int` variant; the big_*-byte variants don't occur for
+// the quantities we read, so treat them as 0.
+fn bigint_to_string(b: &utxorpc::spec::cardano::BigInt) -> String {
+    use utxorpc::spec::cardano::big_int::BigInt;
+
+    match b.big_int.as_ref() {
+        Some(BigInt::Int(i)) => i.to_string(),
+        _ => "0".to_string(),
+    }
 }
 
-#[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct WireCardano {
-    #[serde(default)]
-    coin: Option<WireBigInt>,
-    #[serde(default)]
-    assets: Vec<WireMultiasset>,
-    #[serde(default)]
-    datum: Option<WireDatum>,
-}
+fn flatten_utxo(any: AnyUtxoData) -> UTxO {
+    use utxorpc::spec::cardano::asset::Quantity;
 
-#[derive(Debug, Default, Deserialize)]
-struct WireBigInt {
-    // The plain `int` variant of utxorpc's BigInt oneof — lovelace fits here.
-    // The `bigUInt`/`bigNInt` byte variants don't occur for ADA amounts.
-    #[serde(default)]
-    int: Option<String>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct WireMultiasset {
-    #[serde(default)]
-    policy_id: Option<String>,
-    #[serde(default)]
-    assets: Vec<WireAsset>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct WireAsset {
-    #[serde(default)]
-    name: Option<String>,
-    #[serde(default)]
-    output_coin: Option<String>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct WireDatum {
-    #[serde(default)]
-    hash: Option<String>,
-}
-
-fn decode_b64(s: &str) -> miette::Result<Vec<u8>> {
-    use base64::{engine::general_purpose::STANDARD, Engine as _};
-
-    STANDARD
-        .decode(s)
-        .into_diagnostic()
-        .context("decoding base64 bytes in cshell wallet utxos output")
-}
-
-impl WireUtxo {
-    fn into_utxo(self) -> miette::Result<UTxO> {
-        let cardano = self.cardano.unwrap_or_default();
-
-        let coin = cardano
-            .coin
-            .and_then(|b| b.int)
-            .unwrap_or_else(|| "0".to_string());
-
-        let mut assets = Vec::with_capacity(cardano.assets.len());
-        for multiasset in cardano.assets {
-            let policy_id = match multiasset.policy_id {
-                Some(policy) => decode_b64(&policy)?,
-                None => Vec::new(),
-            };
-
-            let mut inner = Vec::with_capacity(multiasset.assets.len());
-            for asset in multiasset.assets {
-                inner.push(Asset {
-                    name: match asset.name {
-                        Some(name) => decode_b64(&name)?,
-                        None => Vec::new(),
-                    },
-                    output_coin: asset.output_coin.unwrap_or_else(|| "0".to_string()),
-                });
-            }
-
-            assets.push(UtxoAsset {
-                policy_id,
-                assets: inner,
-            });
-        }
-
-        let datum = match cardano.datum.and_then(|d| d.hash) {
-            Some(hash) => Some(Datum {
-                hash: decode_b64(&hash)?,
-            }),
-            None => None,
+    let Some(ParsedState::Cardano(output)) = any.parsed_state else {
+        return UTxO {
+            coin: "0".to_string(),
+            assets: Vec::new(),
+            datum: None,
         };
+    };
 
-        Ok(UTxO {
-            coin,
-            assets,
-            datum,
+    let coin = output
+        .coin
+        .as_ref()
+        .map(bigint_to_string)
+        .unwrap_or_else(|| "0".to_string());
+
+    let assets = output
+        .assets
+        .into_iter()
+        .map(|multiasset| UtxoAsset {
+            policy_id: multiasset.policy_id.to_vec(),
+            assets: multiasset
+                .assets
+                .into_iter()
+                .map(|asset| Asset {
+                    name: asset.name.to_vec(),
+                    output_coin: match asset.quantity {
+                        Some(Quantity::OutputCoin(b)) => bigint_to_string(&b),
+                        _ => "0".to_string(),
+                    },
+                })
+                .collect(),
         })
+        .collect();
+
+    // A no-datum output still carries an (empty) `datum` message; treat an empty
+    // hash as "no datum" so `datum_equals` checks behave as before.
+    let datum = output
+        .datum
+        .filter(|d| !d.hash.is_empty())
+        .map(|d| Datum {
+            hash: d.hash.to_vec(),
+        });
+
+    UTxO {
+        coin,
+        assets,
+        datum,
     }
 }
 
@@ -486,7 +441,7 @@ pub fn wallet_utxos(home: &Path, wallet_name: &str, provider: &str) -> miette::R
         .into_diagnostic()
         .context("parsing cshell wallet utxos output")?;
 
-    parsed.utxos.into_iter().map(WireUtxo::into_utxo).collect()
+    Ok(parsed.utxos.into_iter().map(flatten_utxo).collect())
 }
 
 pub fn explorer(home: &Path, provider: &str) -> miette::Result<Child> {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -39,7 +39,7 @@ fn setup_wallet_key(home: &Path, ident: &str) -> miette::Result<String> {
     Ok(address.to_string())
 }
 
-fn provider_name(trix_profile: &str) -> String {
+pub(crate) fn provider_name(trix_profile: &str) -> String {
     format!("trix-{}", trix_profile)
 }
 


### PR DESCRIPTION
## What

`trix test` resolves and submits the scaffolded transfers fine, but its **expect/balance phase never worked against the released cshell** — it errored with `CShell failed to get wallet utxos` and, on that error path, **leaked the Dolos devnet daemon**. Reproduces on both **stable** (trix 0.25.1) and **beta** (0.26.0), with cshell 0.14 / utxorpc 0.13.

It turned out to be **four layered bugs**, each only visible once the prior is fixed:

1. **`@`-prefix not stripped** — the expect path passed the literal `@bob` placeholder to `cshell wallet utxos`, but wallets are named `bob`. The tx path already strips it (`replace_placeholder_args`); the expect path now mirrors that via a small, unit-tested `wallet_name` helper.
2. **Wrong cshell store** — expect queried `devnet.home` (the *dolos* store), which holds neither the wallets nor the provider. It now queries `wallet.target_dir` — the same cshell home the invoke path submits against.
3. **Missing provider** — `cshell wallet utxos <NAME> <PROVIDER>` falls back to the *default* provider when the positional is omitted, but the generated `cshell.toml` marks its sole provider `is_default = false`. Expect now passes the provider name explicitly (same as invoke), fixing `Wallet and provider not found`.
4. **Stale utxo deserialization** — cshell emits utxorpc `AnyUtxoData` via pbjson (camelCase keys, `bytes` as base64, the `parsed_state` oneof flattened to `cardano`, `BigInt` coin as `{ "int": "..." }`), but the `UTxO` struct expected a flat hex shape and failed with `missing field tx`.

Also: tear the devnet down **unconditionally** so a failed/early-exiting test never leaves a daemon running, and surface cshell's stderr in the utxos error.

## Two commits

- **`fix(test): …`** — fixes bugs 1–3 + the daemon leak, and (bug 4) replaces the stale `UTxO` deserializer. This commit couldn't reuse trix's own utxorpc types: the pinned spec (0.17) modeled cardano `coin` as plain `uint64`, which won't parse cshell's BigInt-shaped coin — so it landed a self-contained wire deserializer.
- **`refactor(test): deserialize cshell utxos via utxorpc AnyUtxoData`** — bumps `utxorpc` 0.12 → 0.13 (matching cshell, spec 0.18, which models `coin` as `BigInt`) and deserializes straight into `utxorpc::spec::query::AnyUtxoData`. pbjson handles the camelCase / base64 / oneof / BigInt shaping, so the hand-rolled wire structs, the base64 decode helper, and the direct `base64` dep all go away (net −63 lines). The bump is otherwise transparent — the only other utxorpc consumer, `devnet/copy.rs`, compiles unchanged.

## Testing

- New unit tests for the `@`-strip; full lib suite (55) green; clippy clean.
- Verified **end-to-end** against the installed beta channel via the umbrella DX e2e harness (`e2e/`, journey `01-basic-init`) after *both* commits: `trix test` on the default scaffold prints `Test Passed`, and no Dolos daemon survives the run.

Surfaced by the umbrella DX e2e harness (tx3-lang/toolchain `e2e/`), which had this round-trip bracketed as an `xfail` on exactly this signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)