### PR TITLE
fix(invoke): exit non-zero when cshell resolve fails

### DIFF
--- a/src/spawn/cshell.rs
+++ b/src/spawn/cshell.rs
@@ -339,12 +339,17 @@ pub fn tx_invoke_interactive(
         provider,
     )?;
 
-    cmd.stdout(Stdio::inherit())
+    let output = cmd
+        .stdout(Stdio::inherit())
         .stdin(Stdio::inherit())
         .stderr(Stdio::inherit())
         .output()
         .into_diagnostic()
         .context("running CShell transaction")?;
+
+    if !output.status.success() {
+        bail!("CShell failed to execute transaction");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

`trix invoke` swallows a failed resolve. `tx_invoke_interactive` (`src/spawn/cshell.rs`) runs cshell via `.output()` but never checks the exit status, so when cshell fails — e.g. a TRP resolve error like `❗️ error: target type not supported: Custom(...)` — the message is printed to the inherited stderr but the function still returns `Ok(())`, and `trix invoke` exits **0**. Callers and CI can't detect the failure by exit code.

## Fix

Capture the command output and bail on a non-success status, exactly as the sibling `tx_invoke_json` already does:

```rust
if !output.status.success() {
    bail!("CShell failed to execute transaction");
}
```

The error then propagates `wallet.invoke_interactive` → `commands/invoke.rs` → `main() -> Result<()>`, so the process exits non-zero. A successful `--skip-submit` invoke still exits 0 and prints `{hash, cbor}` as before.

## Testing

`cargo build`, `cargo clippy`, and `cargo test` all pass (21 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)