### PR TITLE
fix(publish): write OCI `created` into image config so registries order tags

### DIFF
--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -131,6 +131,9 @@ pub async fn run(_args: Args, config: &RootConfig) -> miette::Result<()> {
             name: name.clone(),
             scope: scope.clone(),
             published_date,
+            // OCI-standard creation time so registries (zot) can order tags and
+            // resolve the newest version; mirrors the image.created annotation.
+            created: oci::created_timestamp(published_date),
             repository_url: Some(repository_url.clone()),
             description: config.protocol.description.clone(),
             version: Some(version.clone()),

--- a/src/interfaces/oci.rs
+++ b/src/interfaces/oci.rs
@@ -29,6 +29,12 @@ pub struct ImageMetadata {
     pub name: String,
     pub scope: String,
     pub published_date: i64,
+    /// OCI-standard creation time (RFC3339), derived from `published_date` via
+    /// [`created_timestamp`]. Registries such as zot order a repo's tags by the
+    /// config blob's `created` field to pick the "newest" image; without it they
+    /// fall back to zero time and the first-pushed tag stays newest forever.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<String>,
     /// GitHub `https://github.com/<owner>/<repo>` URL. Mirrors the
     /// `org.opencontainers.image.source` annotation.
     pub repository_url: Option<String>,
@@ -49,6 +55,14 @@ pub struct ImageMetadata {
     /// OIDC-tier publishes will overwrite this from the workflow claim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub commit_sha: Option<String>,
+}
+
+/// OCI-standard `created` timestamp (RFC3339) for an image config, derived from
+/// a Unix-seconds `published_date`. This is the field registries read to order a
+/// repo's tags; see [`ImageMetadata::created`]. Returns `None` only if the
+/// timestamp is out of representable range.
+pub fn created_timestamp(published_date: i64) -> Option<String> {
+    chrono::DateTime::from_timestamp(published_date, 0).map(|dt| dt.to_rfc3339())
 }
 
 pub fn client_for(registry_url: &str) -> oci_client::Client {
@@ -184,6 +198,50 @@ pub async fn pull(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn config_blob_carries_oci_created_for_version_ordering() {
+        // Regression guard. Registries like zot pick a repo's "newest" tag from
+        // the config blob's OCI `created` field (falling back to `history`, else
+        // zero time). With no `created`, every version reads as zero-time and the
+        // FIRST-pushed tag stays "newest" forever — so a GraphQL query for the
+        // latest version of a protocol never advances past the first publish.
+        // The fix: derive an OCI-standard `created` from `published_date` and
+        // serialize it into the image config.
+        let published_date = 1_782_145_366; // 2026-06-22T16:22:46+00:00
+
+        let created = created_timestamp(published_date);
+        assert_eq!(created.as_deref(), Some("2026-06-22T16:22:46+00:00"));
+
+        let meta = ImageMetadata {
+            name: "prueba_zot".into(),
+            scope: "local".into(),
+            published_date,
+            created: created.clone(),
+            repository_url: None,
+            description: None,
+            version: Some("0.2.0".into()),
+            repository: None,
+            commit_sha: None,
+        };
+        let json = serde_json::to_value(&meta).unwrap();
+        assert_eq!(json["created"], "2026-06-22T16:22:46+00:00");
+    }
+
+    #[test]
+    fn config_without_created_still_deserializes() {
+        // Artifacts published before this fix have no `created` field; pulling
+        // them must keep working with `created` defaulting to None.
+        let legacy = r#"{
+            "name": "widget",
+            "scope": "acme",
+            "published_date": 0,
+            "version": "0.1.0"
+        }"#;
+        let meta: ImageMetadata = serde_json::from_str(legacy).unwrap();
+        assert_eq!(meta.created, None);
+        assert_eq!(meta.version.as_deref(), Some("0.1.0"));
+    }
 
     #[test]
     fn reference_lowercases_scope_and_name_for_oci_compliance() {


### PR DESCRIPTION
## fix(publish): write OCI `created` into the image config so registries order tags

### Problem

When publishing two versions of the same protocol (`0.1.0`, then `0.2.0`) to zot, GraphQL search queries always returned the **first version published** as the newest. For example, this
query returned `NewestImage.Tag = "0.1.0"` even though `0.2.0` was pushed afterwards:

```graphql
query GlobalSearch {
  GlobalSearch(requestedPage: { limit: 10, offset: 0, sortBy: ALPHABETIC_DSC } query: "") {
    Repos { Name NewestImage { Tag } LastUpdated }
  }
}
```

The telling detail: in the same response, Repos.LastUpdated correctly reflected the most recent push, but NewestImage pointed at the old tag.

### Root cause

zot selects a repo's "newest" image from the OCI created field of the config blob (GetImageLastUpdated): it reads created first, falls back to history, and otherwise returns zero time
(Jan 1, year 1). The repo's LastUpdatedImage pointer is only replaced when new.After(current).

trix publish declared the config with the standard OCI media type (application/vnd.oci.image.config.v1+json) but wrote a custom JSON with no created (only published_date, a field name zot
doesn't understand). As a result, every version resolved to zero time → zero.After(zero) == false → the second push never replaced the first, and the first-pushed tag stayed "newest"
forever.

Fields derived from the org.opencontainers.image.created annotation (which trix does set correctly) remained accurate — which is why ImageList and Repos.LastUpdated showed the right
order, producing the contradiction.

### Fix

Derive an OCI-standard RFC3339 created from published_date and serialize it into the image config:

- interfaces/oci.rs: new created: Option<String> field on ImageMetadata + a created_timestamp(published_date) helper.
- commands/publish.rs: the config blob now sets created.

The field uses #[serde(default, skip_serializing_if = "Option::is_none")], so artifacts published before this fix still pull without changes.

### Testing / verification

- TDD: a regression test that fails without the fix (config_blob_carries_oci_created_for_version_ordering) plus a backward-compatibility test (config_without_created_still_deserializes).
- Full suite green (57/57), e2e compiles, no clippy findings in the changed code.
- End-to-end against zot: after publishing a new tag with the patched binary, the config carries "created":"…" and the GlobalSearch { NewestImage } query correctly returns the newest
version.